### PR TITLE
Skip non strings in rewrite()

### DIFF
--- a/lib/String/RewritePrefix.pm
+++ b/lib/String/RewritePrefix.pm
@@ -43,6 +43,8 @@ in longest-first order, and only one prefix will be rewritten.
 If the prefix value is a coderef, it will be executed with the remaining string
 as its only argument.  The return value will be used as the prefix.
 
+Any non-scalar values in C<@strings> are ignored.
+
 =cut
 
 sub rewrite {
@@ -70,7 +72,7 @@ sub _new_rewriter {
 
     STRING: for my $str (@_) {
       for (my $i = 0; $i < @rewrites; $i += 2) {
-        if (index($str, $rewrites[$i]) == 0) {
+        if (!ref $str && index($str, $rewrites[$i]) == 0) {
           if (ref $rewrites[$i+1]) {
             my $rest = substr $str, length($rewrites[$i]);
             my $str  = $rewrites[ $i+1 ]->($rest);

--- a/lib/String/RewritePrefix.pm
+++ b/lib/String/RewritePrefix.pm
@@ -43,7 +43,7 @@ in longest-first order, and only one prefix will be rewritten.
 If the prefix value is a coderef, it will be executed with the remaining string
 as its only argument.  The return value will be used as the prefix.
 
-Any non-scalar values in C<@strings> are ignored.
+Any non-scalar values in C<@strings> are passed through untouched.
 
 =cut
 

--- a/t/skip-non-strings.t
+++ b/t/skip-non-strings.t
@@ -1,0 +1,19 @@
+use strict;
+use warnings;
+
+use Test::More tests => 1;
+
+use String::RewritePrefix;
+
+my @to_rewrite = (
+    'Foo::Bar' => { arg => 1 },
+    'Baz',
+);
+
+my @rewritten
+    = String::RewritePrefix->rewrite( { '' => 'MyApp::' }, @to_rewrite );
+
+is_deeply \@rewritten,
+    [ 'MyApp::Foo::Bar' => { arg => 1 }, 'MyApp::Baz' ],
+    "re-writes strings only";
+


### PR DESCRIPTION
Hi,

I was trying to use a parameterized role in MooseX::Storage, and noticed that the list of roles was being processed with String::RewritePrefix and this was preventing me passing the arguments through.

I thought for flexibility it would be nice to allow lists including hashrefs of options to be passed through untouched, as this seems to be a coding style that I've seen in several places, including Moose.

thanks,
Michael
