### PR TITLE
More tests + optimisations

### DIFF
--- a/lib/String/RewritePrefix.pm
+++ b/lib/String/RewritePrefix.pm
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 package String::RewritePrefix;
+
 use Carp ();
 # ABSTRACT: rewrite strings based on a set of known prefixes
 

--- a/lib/String/RewritePrefix.pm
+++ b/lib/String/RewritePrefix.pm
@@ -48,7 +48,7 @@ as its only argument.  The return value will be used as the prefix.
 
 sub rewrite {
   shift; # $self
-  my $rewrites = shift;
+  my $rewrites = shift || {};
 
   Carp::cluck("rewrite invoked in void context")
     unless defined wantarray;

--- a/lib/String/RewritePrefix.pm
+++ b/lib/String/RewritePrefix.pm
@@ -53,8 +53,14 @@ sub rewrite {
   Carp::cluck("rewrite invoked in void context")
     unless defined wantarray;
 
-  Carp::croak("attempt to rewrite multiple strings outside of list context")
-    if @_ > 1 and ! wantarray;
+  # Checks for scalar context
+  unless (wantarray) {
+    if (@_ > 1) {
+      Carp::croak("attempt to rewrite multiple strings outside of list context")
+    } elsif (@_ == 0) {
+      Carp::cluck("rewrite invoked without args")
+    }
+  }
 
   my @prefixes = sort { length $b <=> length $a } keys %$rewrites;
   my @result = @_;
@@ -92,8 +98,14 @@ sub _new_rewriter {
     Carp::cluck("string rewriter invoked in void context")
       unless defined wantarray;
 
-    Carp::croak("attempt to rewrite multiple strings outside of list context")
-      if @_ > 1 and ! wantarray;
+    # Checks for scalar context
+    unless (wantarray) {
+      if (@_ > 1) {
+        Carp::croak("attempt to rewrite multiple strings outside of list context")
+      } elsif (@_ == 0) {
+        Carp::cluck("rewrite invoked without args")
+      }
+    }
 
     my @result = @_;
     for my $str (@result) {

--- a/lib/String/RewritePrefix.pm
+++ b/lib/String/RewritePrefix.pm
@@ -78,13 +78,14 @@ sub rewrite {
 }
 
 sub _new_rewriter {
-  my ($self, $name, $arg) = @_;
-  my $rewrites = $arg->{prefixes} || {};
+  # my ($self, $name, $arg) = @_;
+  my $rewrites = $_[2]->{prefixes} || {};
 
-  my @rewrites;
-  for my $prefix (sort { length $b <=> length $a } keys %$rewrites) {
-    push @rewrites, ($prefix, $rewrites->{$prefix});
-  }
+  my @rewrites =
+    map { ($_, $rewrites->{$_}) }
+    sort { length $b <=> length $a }
+    keys %$rewrites
+  ;
 
   return sub {
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 3;
+use Test::More tests => 4;
 
 use String::RewritePrefix;
 
@@ -49,11 +49,15 @@ is_deeply(
       ''  => 'plus ',
     } }
   );
-  
+
   is_deeply(
     [ pfx_rw(qw(+10 10 -10 0)) ],
     [ 'plus 10', 'plus 10', 'minus 10', 'plus 0' ],
     'rewrote with import',
   );
+
+  # Scalar context
+  my $x = pfx_rw('+2');
+  is($x, 'plus 2', 'scalar context');
 }
 

--- a/t/rewrite_sub.t
+++ b/t/rewrite_sub.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 3*2;
+use Test::More tests => 34;
 
 use String::RewritePrefix ();
 
@@ -20,8 +20,16 @@ sub test_rewrite
     }
   );
   my $rewriter = __PACKAGE__->can($rewriter_name);
+
+  # List context
   is_deeply([ $rewriter->(@$in) ], $expected, $rewriter_name);
   is_deeply([ String::RewritePrefix->rewrite($prefixes, @$in) ], $expected);
+
+  # Scalar context
+  for(my $i=0; $i<=$#$in; $i++) {
+    is_deeply(scalar $rewriter->($in->[$i]), $expected->[$i], "$in->[$i] => $expected->[$i]");
+    is_deeply(scalar String::RewritePrefix->rewrite($prefixes, $in->[$i]), $expected->[$i]);
+  }
 }
 
 

--- a/t/rewrite_sub.t
+++ b/t/rewrite_sub.t
@@ -1,0 +1,53 @@
+use strict;
+use warnings;
+
+use Test::More tests => 3*2;
+
+use String::RewritePrefix ();
+
+
+my $rewriter_num = 0;
+
+sub test_rewrite
+{
+  my ($prefixes, $in, $expected) = @_;
+
+  my $rewriter_name = "rewriter_".(++$rewriter_num);
+  String::RewritePrefix->import(
+    rewrite => {
+      -as => $rewriter_name,
+      prefixes => $prefixes,
+    }
+  );
+  my $rewriter = __PACKAGE__->can($rewriter_name);
+  is_deeply([ $rewriter->(@$in) ], $expected, $rewriter_name);
+  is_deeply([ String::RewritePrefix->rewrite($prefixes, @$in) ], $expected);
+}
+
+
+test_rewrite({
+    '-' => 'Tet::',
+    '@' => 'KaTet::',
+    '+' => sub { $_[0] . '::Foo::' },
+    '!' => sub { return undef },
+  },
+  [ qw(    -Corporation       @Roller Plinko     -@Oops          +Bar !None)],
+  [ qw(Tet::Corporation KaTet::Roller Plinko Tet::@Oops Bar::Foo::Bar  None) ],
+);
+
+test_rewrite(
+  { '' => 'MyApp::', '+' => '' },
+  [ qw(       Plugin        Mixin        Addon +Corporate::Thinger) ],
+  [ qw(MyApp::Plugin MyApp::Mixin MyApp::Addon  Corporate::Thinger) ],
+);
+
+
+test_rewrite({
+    '-' => 'minus ',
+    '+' => 'plus ',
+    ''  => 'plus ',
+  },
+  [ qw(  +10         10         -10         0) ],
+  [ 'plus 10', 'plus 10', 'minus 10', 'plus 0' ],
+);
+


### PR DESCRIPTION
- Fix for [PkgVersion]
- Add more tests to check that the behaviour of the `rewrite` sub is the same as the generated rewriters
- Inline the rewriter code into `rewrite()` instead of creating a short living rewriter 
- Optimisations:
  - use 4 args substr
  - return early in scalar context
  - copy-args+modify-in-place instead of copy+modify+push-in-array
- Cluck if no args in scalar context
